### PR TITLE
Exclude 'exclude-upstream-addresses' config parameter.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,17 +24,6 @@
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 
 [[projects]]
-  name = "github.com/monitoring-tools/prom-nginx-exporter"
-  packages = [
-    "common",
-    "exporter",
-    "metric",
-    "scraper"
-  ]
-  revision = "bea72f0ed5758a83f92aecf6fe18447f8f101b0d"
-  version = "1.0.0"
-
-[[projects]]
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -84,6 +73,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1a5775ae20a231f48b51aaeb1166cdc65a4eabe6a732dbb9f944da4b34d98311"
+  inputs-digest = "0f66c13ab27e197b3251ad27e59f52a8e3468ab67282d2d50888c4f8bfe94bb5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ metrics-path          |    no    |    no    | /metrics       | Path under which 
 namespace             |    no    |    no    | nginx          | The namespace of metrics.
 nginx-stats-urls      |    yes   |    yes   | -              | An array of Nginx URL to gather stats.
 nginx-plus-stats-urls |    yes   |    yes   | -              | An array of Nginx Plus URL to gather stats.
+exclude-upstream-peers|    no    |    yes   | -              | An array of peers addresses to exclude in the gathering of metrics.
 
 ## What's exported?
 It exports statistics of standart Nginx module (https://nginx.org/en/docs/http/ngx_http_stub_status_module.html) and Nginx Plus module (http://nginx.org/en/docs/http/ngx_http_status_module.html).

--- a/common/config.go
+++ b/common/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	Namespace            string
 	NginxUrls            []string
 	NginxPlusUrls        []string
-	ExcludeUpstreamPeers []string
+	ExcludeUpstreamPeers map[string]bool
 }
 
 // NewConfig creates new application config.
@@ -17,7 +17,7 @@ func NewConfig(
 	namespace string,
 	nginxUrls []string,
 	nginxPlusUrls []string,
-	excludeUpstreamPeers []string,
+	excludeUpstreamPeers map[string]bool,
 ) *Config {
 	return &Config{
 		ListenAddress:        listenAddress,

--- a/common/config.go
+++ b/common/config.go
@@ -2,20 +2,29 @@ package common
 
 // Config is the struct of application config.
 type Config struct {
-	ListenAddress string
-	MetricsPath   string
-	Namespace     string
-	NginxUrls     []string
-	NginxPlusUrls []string
+	ListenAddress            string
+	MetricsPath              string
+	Namespace                string
+	NginxUrls                []string
+	NginxPlusUrls            []string
+	ExcludeUpstreamAddresses []string
 }
 
 // NewConfig creates new application config.
-func NewConfig(listenAddress string, metricsPath string, namespace string, nginxUrls []string, nginxPlusUrls []string) *Config {
+func NewConfig(
+	listenAddress string,
+	metricsPath string,
+	namespace string,
+	nginxUrls []string,
+	nginxPlusUrls []string,
+	excludeUpstreamAddresses []string,
+) *Config {
 	return &Config{
-		ListenAddress: listenAddress,
-		MetricsPath:   metricsPath,
-		Namespace:     namespace,
-		NginxUrls:     nginxUrls,
-		NginxPlusUrls: nginxPlusUrls,
+		ListenAddress:            listenAddress,
+		MetricsPath:              metricsPath,
+		Namespace:                namespace,
+		NginxUrls:                nginxUrls,
+		NginxPlusUrls:            nginxPlusUrls,
+		ExcludeUpstreamAddresses: excludeUpstreamAddresses,
 	}
 }

--- a/common/config.go
+++ b/common/config.go
@@ -2,12 +2,12 @@ package common
 
 // Config is the struct of application config.
 type Config struct {
-	ListenAddress            string
-	MetricsPath              string
-	Namespace                string
-	NginxUrls                []string
-	NginxPlusUrls            []string
-	ExcludeUpstreamAddresses []string
+	ListenAddress        string
+	MetricsPath          string
+	Namespace            string
+	NginxUrls            []string
+	NginxPlusUrls        []string
+	ExcludeUpstreamPeers []string
 }
 
 // NewConfig creates new application config.
@@ -17,14 +17,14 @@ func NewConfig(
 	namespace string,
 	nginxUrls []string,
 	nginxPlusUrls []string,
-	excludeUpstreamAddresses []string,
+	excludeUpstreamPeers []string,
 ) *Config {
 	return &Config{
-		ListenAddress:            listenAddress,
-		MetricsPath:              metricsPath,
-		Namespace:                namespace,
-		NginxUrls:                nginxUrls,
-		NginxPlusUrls:            nginxPlusUrls,
-		ExcludeUpstreamAddresses: excludeUpstreamAddresses,
+		ListenAddress:        listenAddress,
+		MetricsPath:          metricsPath,
+		Namespace:            namespace,
+		NginxUrls:            nginxUrls,
+		NginxPlusUrls:        nginxPlusUrls,
+		ExcludeUpstreamPeers: excludeUpstreamPeers,
 	}
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -208,7 +208,7 @@ func (s NginxExporterSuite) TestNginxStatsScrape_Success(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper([]string{}),
+		scraper.NewNginxPlusScraper(map[string]bool{}),
 		"nginx_test",
 		[]string{"http://localhost:9000"},
 		[]string{},
@@ -263,7 +263,7 @@ func (s NginxExporterSuite) TestNginxPlusStatsScrape_Success(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper([]string{}),
+		scraper.NewNginxPlusScraper(map[string]bool{}),
 		"nginx_test",
 		[]string{},
 		[]string{"http://localhost:9000"},
@@ -407,7 +407,7 @@ func (s NginxExporterSuite) TestInvalidNginxStatsUrl_Fail(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper([]string{}),
+		scraper.NewNginxPlusScraper(map[string]bool{}),
 		"nginx_test",
 		[]string{"invalid nginx stats url"},
 		[]string{},

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -208,7 +208,7 @@ func (s NginxExporterSuite) TestNginxStatsScrape_Success(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper(),
+		scraper.NewNginxPlusScraper([]string{}),
 		"nginx_test",
 		[]string{"http://localhost:9000"},
 		[]string{},
@@ -263,7 +263,7 @@ func (s NginxExporterSuite) TestNginxPlusStatsScrape_Success(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper(),
+		scraper.NewNginxPlusScraper([]string{}),
 		"nginx_test",
 		[]string{},
 		[]string{"http://localhost:9000"},
@@ -407,7 +407,7 @@ func (s NginxExporterSuite) TestInvalidNginxStatsUrl_Fail(c *C) {
 	exp := exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper(),
+		scraper.NewNginxPlusScraper([]string{}),
 		"nginx_test",
 		[]string{"invalid nginx stats url"},
 		[]string{},

--- a/main.go
+++ b/main.go
@@ -73,11 +73,16 @@ func parseFlag() (*common.Config, error) {
 		return nil, errors.New("no nginx or nginx plus stats url specified")
 	}
 
-	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls, excludeUpstreamPeers), nil
+	peers := make(map[string]bool)
+	for _, peer := range excludeUpstreamPeers {
+		peers[peer] = true
+	}
+
+	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls, peers), nil
 }
 
 // registerExporter registers custom nginx metrics exporter
-func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string, excludeUpstreamPeers []string) {
+func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string, excludeUpstreamPeers map[string]bool) {
 	var (
 		transport = &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
 		client    = &http.Client{Transport: transport, Timeout: time.Duration(4 * time.Second)}

--- a/main.go
+++ b/main.go
@@ -38,19 +38,20 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	registerExporter(config.Namespace, config.NginxUrls, config.NginxPlusUrls)
+	registerExporter(config.Namespace, config.NginxUrls, config.NginxPlusUrls, config.ExcludeUpstreamAddresses)
 	run(config.ListenAddress, config.MetricsPath)
 }
 
 // parseFlag parses config parameters
 func parseFlag() (*common.Config, error) {
 	var (
-		listenAddress *string
-		metricsPath   *string
-		namespace     *string
-		version       *bool
-		nginxUrls     common.ArrFlags
-		nginxPlusUrls common.ArrFlags
+		listenAddress            *string
+		metricsPath              *string
+		namespace                *string
+		version                  *bool
+		nginxUrls                common.ArrFlags
+		nginxPlusUrls            common.ArrFlags
+		excludeUpstreamAddresses common.ArrFlags
 	)
 
 	listenAddress = flag.String("listen-address", ":9001", "Address on which to expose metrics and web interface.")
@@ -59,6 +60,7 @@ func parseFlag() (*common.Config, error) {
 	version = flag.Bool("version", false, "The version of the exporter.")
 	flag.Var(&nginxUrls, "nginx-stats-urls", "An array of Nginx status URLs to gather stats.")
 	flag.Var(&nginxPlusUrls, "nginx-plus-stats-urls", "An array of Nginx Plus status URLs to gather stats.")
+	flag.Var(&excludeUpstreamAddresses, "exclude-upstream-addresses", "An array of upstream addresses that need to be excluded in gathering stats.")
 
 	flag.Parse()
 
@@ -71,11 +73,11 @@ func parseFlag() (*common.Config, error) {
 		return nil, errors.New("no nginx or nginx plus stats url specified")
 	}
 
-	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls), nil
+	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls, excludeUpstreamAddresses), nil
 }
 
 // registerExporter registers custom nginx metrics exporter
-func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string) {
+func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string, excludeUpstreamAddresses []string) {
 	var (
 		transport = &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
 		client    = &http.Client{Transport: transport, Timeout: time.Duration(4 * time.Second)}
@@ -84,7 +86,7 @@ func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []stri
 	prometheus.MustRegister(exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper(),
+		scraper.NewNginxPlusScraper(excludeUpstreamAddresses),
 		namespace,
 		nginxUrls,
 		nginxPlusUrls,

--- a/main.go
+++ b/main.go
@@ -38,20 +38,20 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	registerExporter(config.Namespace, config.NginxUrls, config.NginxPlusUrls, config.ExcludeUpstreamAddresses)
+	registerExporter(config.Namespace, config.NginxUrls, config.NginxPlusUrls, config.ExcludeUpstreamPeers)
 	run(config.ListenAddress, config.MetricsPath)
 }
 
 // parseFlag parses config parameters
 func parseFlag() (*common.Config, error) {
 	var (
-		listenAddress            *string
-		metricsPath              *string
-		namespace                *string
-		version                  *bool
-		nginxUrls                common.ArrFlags
-		nginxPlusUrls            common.ArrFlags
-		excludeUpstreamAddresses common.ArrFlags
+		listenAddress        *string
+		metricsPath          *string
+		namespace            *string
+		version              *bool
+		nginxUrls            common.ArrFlags
+		nginxPlusUrls        common.ArrFlags
+		excludeUpstreamPeers common.ArrFlags
 	)
 
 	listenAddress = flag.String("listen-address", ":9001", "Address on which to expose metrics and web interface.")
@@ -60,7 +60,7 @@ func parseFlag() (*common.Config, error) {
 	version = flag.Bool("version", false, "The version of the exporter.")
 	flag.Var(&nginxUrls, "nginx-stats-urls", "An array of Nginx status URLs to gather stats.")
 	flag.Var(&nginxPlusUrls, "nginx-plus-stats-urls", "An array of Nginx Plus status URLs to gather stats.")
-	flag.Var(&excludeUpstreamAddresses, "exclude-upstream-addresses", "An array of upstream addresses that need to be excluded in gathering stats.")
+	flag.Var(&excludeUpstreamPeers, "exclude-upstream-peers", "An array of upstream addresses that need to be excluded in gathering stats.")
 
 	flag.Parse()
 
@@ -73,11 +73,11 @@ func parseFlag() (*common.Config, error) {
 		return nil, errors.New("no nginx or nginx plus stats url specified")
 	}
 
-	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls, excludeUpstreamAddresses), nil
+	return common.NewConfig(*listenAddress, *metricsPath, *namespace, nginxUrls, nginxPlusUrls, excludeUpstreamPeers), nil
 }
 
 // registerExporter registers custom nginx metrics exporter
-func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string, excludeUpstreamAddresses []string) {
+func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []string, excludeUpstreamPeers []string) {
 	var (
 		transport = &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
 		client    = &http.Client{Transport: transport, Timeout: time.Duration(4 * time.Second)}
@@ -86,7 +86,7 @@ func registerExporter(namespace string, nginxUrls []string, nginxPlusUrls []stri
 	prometheus.MustRegister(exporter.NewNginxPlusExporter(
 		client,
 		scraper.NewNginxScraper(),
-		scraper.NewNginxPlusScraper(excludeUpstreamAddresses),
+		scraper.NewNginxPlusScraper(excludeUpstreamPeers),
 		namespace,
 		nginxUrls,
 		nginxPlusUrls,

--- a/scraper/nginx_plus.go
+++ b/scraper/nginx_plus.go
@@ -252,6 +252,20 @@ func (scr *NginxPlusScraper) scrapeStream(status *Status, metrics chan<- metric.
 		metrics <- metric.NewMetric("stream_upstream_zombies", upstream.Zombies, upstreamLabels)
 
 		for _, peer := range upstream.Peers {
+			if len(scr.excludeUpstreamAddresses) != 0 {
+				exclude := false
+				for _, address := range scr.excludeUpstreamAddresses {
+					if address == peer.Server {
+						exclude = true
+						break
+					}
+				}
+
+				if exclude {
+					continue
+				}
+			}
+
 			peerLables := map[string]string{}
 			for k, v := range upstreamLabels {
 				peerLables[k] = v

--- a/scraper/nginx_plus.go
+++ b/scraper/nginx_plus.go
@@ -11,11 +11,11 @@ import (
 
 // NginxPlusScraper is scraper for getting nginx plus metrics
 type NginxPlusScraper struct {
-	excludeUpstreamPeers []string
+	excludeUpstreamPeers map[string]bool
 }
 
 // NewNginxPlusScraper crates new nginx plus stats scraper
-func NewNginxPlusScraper(excludeUpstreamPeers []string) NginxPlusScraper {
+func NewNginxPlusScraper(excludeUpstreamPeers map[string]bool) NginxPlusScraper {
 	return NginxPlusScraper{excludeUpstreamPeers: excludeUpstreamPeers}
 }
 
@@ -121,18 +121,8 @@ func (scr *NginxPlusScraper) scrapeUpstream(status *Status, metrics chan<- metri
 		}
 
 		for _, peer := range upstream.Peers {
-			if len(scr.excludeUpstreamPeers) != 0 {
-				exclude := false
-				for _, address := range scr.excludeUpstreamPeers {
-					if address == peer.Server {
-						exclude = true
-						break
-					}
-				}
-
-				if exclude {
-					continue
-				}
+			if ok := scr.excludeUpstreamPeers[peer.Server]; ok {
+				continue
 			}
 
 			peerLabels := make(map[string]string)
@@ -252,18 +242,8 @@ func (scr *NginxPlusScraper) scrapeStream(status *Status, metrics chan<- metric.
 		metrics <- metric.NewMetric("stream_upstream_zombies", upstream.Zombies, upstreamLabels)
 
 		for _, peer := range upstream.Peers {
-			if len(scr.excludeUpstreamPeers) != 0 {
-				exclude := false
-				for _, address := range scr.excludeUpstreamPeers {
-					if address == peer.Server {
-						exclude = true
-						break
-					}
-				}
-
-				if exclude {
-					continue
-				}
+			if ok := scr.excludeUpstreamPeers[peer.Server]; ok {
+				continue
 			}
 
 			peerLables := map[string]string{}

--- a/scraper/nginx_plus.go
+++ b/scraper/nginx_plus.go
@@ -11,12 +11,12 @@ import (
 
 // NginxPlusScraper is scraper for getting nginx plus metrics
 type NginxPlusScraper struct {
-	excludeUpstreamAddresses []string
+	excludeUpstreamPeers []string
 }
 
 // NewNginxPlusScraper crates new nginx plus stats scraper
-func NewNginxPlusScraper(excludeUpstreamAddresses []string) NginxPlusScraper {
-	return NginxPlusScraper{excludeUpstreamAddresses: excludeUpstreamAddresses}
+func NewNginxPlusScraper(excludeUpstreamPeers []string) NginxPlusScraper {
+	return NginxPlusScraper{excludeUpstreamPeers: excludeUpstreamPeers}
 }
 
 // Scrape scrapes stats from nginx plus module
@@ -121,9 +121,9 @@ func (scr *NginxPlusScraper) scrapeUpstream(status *Status, metrics chan<- metri
 		}
 
 		for _, peer := range upstream.Peers {
-			if len(scr.excludeUpstreamAddresses) != 0 {
+			if len(scr.excludeUpstreamPeers) != 0 {
 				exclude := false
-				for _, address := range scr.excludeUpstreamAddresses {
+				for _, address := range scr.excludeUpstreamPeers {
 					if address == peer.Server {
 						exclude = true
 						break
@@ -252,9 +252,9 @@ func (scr *NginxPlusScraper) scrapeStream(status *Status, metrics chan<- metric.
 		metrics <- metric.NewMetric("stream_upstream_zombies", upstream.Zombies, upstreamLabels)
 
 		for _, peer := range upstream.Peers {
-			if len(scr.excludeUpstreamAddresses) != 0 {
+			if len(scr.excludeUpstreamPeers) != 0 {
 				exclude := false
-				for _, address := range scr.excludeUpstreamAddresses {
+				for _, address := range scr.excludeUpstreamPeers {
 					if address == peer.Server {
 						exclude = true
 						break

--- a/scraper/nginx_plus.go
+++ b/scraper/nginx_plus.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/monitoring-tools/prom-nginx-exporter/metric"
 )
@@ -141,9 +140,6 @@ func (scr *NginxPlusScraper) scrapeUpstream(status *Status, metrics chan<- metri
 				peerLabels[k] = v
 			}
 			peerLabels["serverAddress"] = peer.Server
-			if peer.ID != nil {
-				peerLabels["id"] = strconv.Itoa(*peer.ID)
-			}
 
 			metrics <- metric.NewMetric("upstream_peer_backup", peer.Backup, peerLabels)
 			metrics <- metric.NewMetric("upstream_peer_weight", peer.Weight, peerLabels)

--- a/scraper/nginx_plus.go
+++ b/scraper/nginx_plus.go
@@ -24,7 +24,7 @@ func (scr *NginxPlusScraper) Scrape(body io.Reader, metrics chan<- metric.Metric
 
 	status := &Status{}
 	if err := dec.Decode(status); err != nil {
-		return fmt.Errorf("Error while decoding JSON response")
+		return fmt.Errorf("error while decoding JSON response: %s", err)
 	}
 
 	scr.scrapeProcesses(status, metrics, labels)
@@ -245,7 +245,6 @@ func (scr *NginxPlusScraper) scrapeStream(status *Status, metrics chan<- metric.
 				peerLables[k] = v
 			}
 			peerLables["serverAddress"] = peer.Server
-			peerLables["id"] = strconv.Itoa(peer.ID)
 
 			metrics <- metric.NewMetric("stream_upstream_peer_backup", peer.Backup, peerLables)
 			metrics <- metric.NewMetric("stream_upstream_peer_weight", peer.Weight, peerLables)

--- a/scraper/nginx_plus_test.go
+++ b/scraper/nginx_plus_test.go
@@ -232,7 +232,7 @@ func codeLabels(labels map[string]string, code string) map[string]string {
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
-	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{"10.20.30.40:5566"})
+	nginxPlusScraper := scraper.NewNginxPlusScraper(map[string]bool{"10.20.30.40:5566": true})
 	reader := strings.NewReader(validNginxPlusStats)
 
 	metrics := make(chan metric.Metric, 109)
@@ -838,7 +838,7 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 
 	// if the 'upstream.02' upstream is the second in the upstreams loop
 	if len(metrics) == 1 {
-		m = <- metrics
+		m = <-metrics
 		streamUpstreamLabels["upstream"] = "upstream.02"
 		c.Assert(m.Name, Equals, "stream_upstream_zombies", Commentf("incorrect metrics name of 'stream_upstream_zombies' field"))
 		c.Assert(m.Value, Equals, 10, Commentf("incorrect value of metric 'stream_upstream_zombies'"))
@@ -847,7 +847,7 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Fail(c *C) {
-	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{})
+	nginxPlusScraper := scraper.NewNginxPlusScraper(map[string]bool{})
 	reader := strings.NewReader(`{"version":"invalid json"}`)
 
 	metrics := make(chan metric.Metric, 96)

--- a/scraper/nginx_plus_test.go
+++ b/scraper/nginx_plus_test.go
@@ -185,6 +185,36 @@ var validNginxPlusStats = `
                     }
                 ],
                 "zombies": 0
+            },
+			"upstream.02": {
+                "peers": [
+                    {
+                        "id": 2,
+                        "server": "10.20.30.40:5566",
+                        "backup": true,
+                        "weight": 1,
+                        "state": "up",
+                        "active": 100,
+                        "connections": 120,
+                        "sent": 130,
+                        "received": 23,
+                        "fails": 0,
+                        "unavail": 1,
+                        "downtime": 2,
+                        "downstart": 3,
+                        "selected": 4,
+                        "health_checks": {
+                            "checks": 4005,
+                            "fails": 40,
+                            "unhealthy": 100,
+                            "last_passed": true
+                        },
+                        "connect_time": 553,
+                        "first_byte_time": 554,
+                        "response_time": 555
+                    }
+                ],
+                "zombies": 10
             }
         }
     }
@@ -202,10 +232,10 @@ func codeLabels(labels map[string]string, code string) map[string]string {
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
-	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{})
+	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{"10.20.30.40:5566"})
 	reader := strings.NewReader(validNginxPlusStats)
 
-	metrics := make(chan metric.Metric, 108)
+	metrics := make(chan metric.Metric, 109)
 	labels := map[string]string{
 		"host": "zone.a_80",
 		"port": "8080",
@@ -688,9 +718,19 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 	for l, v := range labels {
 		streamUpstreamLabels[l] = v
 	}
-	streamUpstreamLabels["upstream"] = "upstream.01"
 
 	m = <-metrics
+
+	// if the 'upstream.02' upstream is the first in upstreams loop
+	if m.Value == 10 {
+		streamUpstreamLabels["upstream"] = "upstream.02"
+		c.Assert(m.Name, Equals, "stream_upstream_zombies", Commentf("incorrect metrics name of 'stream_upstream_zombies' field"))
+		c.Assert(m.Labels, DeepEquals, streamUpstreamLabels, Commentf("incorrect set of labels"))
+		m = <-metrics
+	}
+
+	streamUpstreamLabels["upstream"] = "upstream.01"
+
 	c.Assert(m.Name, Equals, "stream_upstream_zombies", Commentf("incorrect metrics name of 'stream_upstream_zombies' field"))
 	c.Assert(m.Value, Equals, 0, Commentf("incorrect value of metric 'stream_upstream_zombies'"))
 	c.Assert(m.Labels, DeepEquals, streamUpstreamLabels, Commentf("incorrect set of labels"))
@@ -795,6 +835,15 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 	c.Assert(m.Name, Equals, "stream_upstream_peer_response_time", Commentf("incorrect metrics name of 'stream_upstream_peer_response_time' field"))
 	c.Assert(m.Value, Equals, 995, Commentf("incorrect value of metric 'stream_upstream_peer_response_time'"))
 	c.Assert(m.Labels, DeepEquals, streamPeerLabels, Commentf("incorrect set of labels"))
+
+	// if the 'upstream.02' upstream is the second in the upstreams loop
+	if len(metrics) == 1 {
+		m = <- metrics
+		streamUpstreamLabels["upstream"] = "upstream.02"
+		c.Assert(m.Name, Equals, "stream_upstream_zombies", Commentf("incorrect metrics name of 'stream_upstream_zombies' field"))
+		c.Assert(m.Value, Equals, 10, Commentf("incorrect value of metric 'stream_upstream_zombies'"))
+		c.Assert(m.Labels, DeepEquals, streamUpstreamLabels, Commentf("incorrect set of labels"))
+	}
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Fail(c *C) {

--- a/scraper/nginx_plus_test.go
+++ b/scraper/nginx_plus_test.go
@@ -202,7 +202,7 @@ func codeLabels(labels map[string]string, code string) map[string]string {
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
-	nginxPlusScraper := scraper.NewNginxPlusScraper()
+	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{})
 	reader := strings.NewReader(validNginxPlusStats)
 
 	metrics := make(chan metric.Metric, 108)
@@ -385,7 +385,6 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 	for l, v := range upstreamLabels {
 		peerLabels[l] = v
 	}
-	peerLabels["id"] = "0"
 	peerLabels["serverAddress"] = "1.2.3.123:80"
 
 	m = <-metrics
@@ -701,7 +700,6 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 		streamPeerLabels[l] = v
 	}
 	streamPeerLabels["serverAddress"] = "5.4.3.2:2345"
-	streamPeerLabels["id"] = "1"
 
 	m = <-metrics
 	c.Assert(m.Name, Equals, "stream_upstream_peer_backup", Commentf("incorrect metrics name of 'stream_upstream_peer_backup' field"))
@@ -800,7 +798,7 @@ func (s NginxPlusScraperSuite) TestScrape_Success(c *C) {
 }
 
 func (s NginxPlusScraperSuite) TestScrape_Fail(c *C) {
-	nginxPlusScraper := scraper.NewNginxPlusScraper()
+	nginxPlusScraper := scraper.NewNginxPlusScraper([]string{})
 	reader := strings.NewReader(`{"version":"invalid json"}`)
 
 	metrics := make(chan metric.Metric, 96)
@@ -808,5 +806,5 @@ func (s NginxPlusScraperSuite) TestScrape_Fail(c *C) {
 
 	err := nginxPlusScraper.Scrape(reader, metrics, labels)
 	c.Assert(err, NotNil, Commentf("error should be occurred"))
-	c.Assert(err.Error(), Equals, "Error while decoding JSON response", Commentf("incorrect error massage of parsing json"))
+	c.Assert(err.Error(), Equals, "error while decoding JSON response: json: cannot unmarshal string into Go struct field Status.version of type int", Commentf("incorrect error massage of parsing json"))
 }


### PR DESCRIPTION
The following changes were made:
 - The 'exclude-upstream-addresses' config parameter was added to exclude upstream addresses.
 - The gathering of peer id metric was removed.